### PR TITLE
Fix structured YAML array parsing for Tekton tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,16 +89,32 @@ spec:
 
 ### Using Parameters in Templates
 
-When creating templates, you can access any parameter by its camel-cased name. For parameters containing tasks, you also have access to the task names:
+When creating templates, you can access any parameter by its camel-cased name. For parameters containing tasks, you also have access to the task objects, names, and formatted YAML:
 
 ```yaml
-# Example: Using a task parameter
+# Example 1: Using a task parameter directly (legacy approach)
 {{- if .ValidationSteps }}
 # Include the validation tasks
 {{ .ValidationSteps }}
 {{- end }}
 
-# Example: Using task names from parameters
+# Example 2: Iterating over structured task objects (recommended)
+{{- if .ValidationStepsObjects }}
+{{- range $index, $task := .ValidationStepsObjects }}
+- name: {{ $task.name }}
+  taskRef:
+    name: {{ index $task.taskRef "name" }}
+  {{- if $task.params }}
+  params:
+  {{- range $task.params }}
+    - name: {{ .name }}
+      value: {{ .value }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+# Example 3: Using task names from parameters
 - name: next-task
   runAfter:
   {{- if .ValidationStepsNames }}
@@ -109,13 +125,13 @@ When creating templates, you can access any parameter by its camel-cased name. F
   - default-task
   {{- end }}
 
-# Example: Using a regular array parameter
+# Example 4: Using a regular array parameter
 allowed-environments:
 {{- range .AllowedEnvironments }}
 - {{ . }}
 {{- end }}
 
-# Example: Using a regular string parameter
+# Example 5: Using a regular string parameter
 app-name: {{ .AppName }}
 ```
 
@@ -239,6 +255,8 @@ For more detailed information about available commands, examine the Taskfile.yml
 - **Consistent Naming Convention**: All parameters are converted to camelCase for template use
 - **Task Name Extraction**: Task names are automatically extracted for use in dependencies
 - **Flexible Parameter Formats**: Works with both array parameters and string parameters containing YAML
+- **Structured Object Access**: Use direct iteration over task objects with full access to all properties
+- **Backwards Compatibility**: Maintains support for legacy template formats
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- Fixed issue with parsing structured YAML arrays in template parameters
- Added special handling for task-like objects in array parameters
- Template can now iterate directly over parsed task objects
- Improved template rendering for complex YAML task structures

## Problem
When passing complex YAML structures like tasks via parameters (e.g., post-dev-steps), the template resolver wasn't correctly parsing them as objects that could be iterated with Go templates. Instead, they were being treated as strings, causing errors like:

```
error getting "Template": failed to render template: template: pipeline:155:23: executing "pipeline" at <$steps>: range can't iterate over '[{"name":"run-integration-tests"...
```

## Solution
- Detect array parameters that might contain task definitions
- Parse the combined array as JSON to preserve the structured data
- Store parsed task objects directly in the template data for iteration
- Store task names for use in runAfter declarations
- Maintain backward compatibility with formatted YAML strings

## Test Plan
- Test with existing template structure
- Test with various complex YAML task definitions in parameters
- Verify that template can properly iterate over task objects
- Ensure backward compatibility with existing templates

🤖 Generated with [Claude Code](https://claude.ai/code)